### PR TITLE
Improve generation performance by removing UT logic from normal generation

### DIFF
--- a/worlds/banjo_tooie/Regions.py
+++ b/worlds/banjo_tooie/Regions.py
@@ -6,7 +6,7 @@ from .Options import VictoryCondition
 
 from .Names import regionName, locationName, itemName
 from .Locations import BanjoTooieLocation
-from .Rules import BanjoTooieRules
+from .Rules import BanjoTooieRules, BanjoTooieUniversalTrackerRules
 
 # This dict contains all the regions, as well as all the locations that are always tracked by Archipelago.
 BANJO_TOOIE_REGIONS: Dict[str, List[str]] = {
@@ -1615,7 +1615,11 @@ def create_region(world, active_locations, name: str, locations=None):
 
 def connect_regions(self):
     player = self.player
-    rules = BanjoTooieRules(self)
+
+    if hasattr(self.multiworld, "generation_is_fake"):
+        rules = BanjoTooieUniversalTrackerRules(self)
+    else:
+        rules = BanjoTooieRules(self)
 
     region_menu = self.get_region(regionName.MENU)
     region_menu.add_exits({regionName.SM})

--- a/worlds/banjo_tooie/Rules.py
+++ b/worlds/banjo_tooie/Rules.py
@@ -6203,16 +6203,16 @@ class BanjoTooieRules:
         return self.has_BK_move(state, itemName.TTRAIN) or state.has(itemName.PSHOES, self.player, 2)
 
     def intended_logic(self, state: CollectionState) -> bool:
-        return self.world.options.logic_type.value == LogicType.option_intended and not state.has(itemName.UT_GLITCHED, self.player)
+        return self.world.options.logic_type.value == LogicType.option_intended
 
     def easy_tricks_logic(self, state: CollectionState) -> bool:
-        return self.world.options.logic_type.value == LogicType.option_easy_tricks and not state.has(itemName.UT_GLITCHED, self.player)
+        return self.world.options.logic_type.value == LogicType.option_easy_tricks
 
     def hard_tricks_logic(self, state: CollectionState) -> bool:
-        return self.world.options.logic_type.value == LogicType.option_hard_tricks and not state.has(itemName.UT_GLITCHED, self.player)
+        return self.world.options.logic_type.value == LogicType.option_hard_tricks
 
     def glitches_logic(self, state: CollectionState) -> bool:
-        return self.world.options.logic_type.value == LogicType.option_glitches or state.has(itemName.UT_GLITCHED, self.player)
+        return self.world.options.logic_type.value == LogicType.option_glitches
 
 
     def long_jump(self, state: CollectionState) -> bool:
@@ -6790,3 +6790,17 @@ class BanjoTooieRules:
             self.world.multiworld.completion_condition[self.player] = self.victory_hag1
         else:
             self.world.multiworld.completion_condition[self.player] = self.victory_hag1
+
+
+class BanjoTooieUniversalTrackerRules(BanjoTooieRules):
+    def intended_logic(self, state: CollectionState) -> bool:
+        return super().intended_logic(state) and not state.has(itemName.UT_GLITCHED, self.player)
+
+    def easy_tricks_logic(self, state: CollectionState) -> bool:
+        return super().easy_tricks_logic(state) and not state.has(itemName.UT_GLITCHED, self.player)
+
+    def hard_tricks_logic(self, state: CollectionState) -> bool:
+        return super().hard_tricks_logic(state) and not state.has(itemName.UT_GLITCHED, self.player)
+
+    def glitches_logic(self, state: CollectionState) -> bool:
+        return super().glitches_logic(state) or state.has(itemName.UT_GLITCHED, self.player)

--- a/worlds/banjo_tooie/__init__.py
+++ b/worlds/banjo_tooie/__init__.py
@@ -19,7 +19,7 @@ from .Locations import LocationData, all_location_table, MTLoc_Table, GMLoc_tabl
 from .Regions import create_regions, connect_regions
 from .Options import BanjoTooieOptions, EggsBehaviour, JamjarsSiloCosts, LogicType, ProgressiveEggAim, \
     ProgressiveWaterTraining, RandomizeBKMoveList, VictoryCondition, bt_option_groups, WorldRequirements
-from .Rules import BanjoTooieRules
+from .Rules import BanjoTooieRules, BanjoTooieUniversalTrackerRules
 from .Names import itemName, locationName, regionName
 from .WorldOrder import randomize_world_progression
 from BaseClasses import ItemClassification, Location, MultiWorld, Tutorial, Item
@@ -730,7 +730,10 @@ class BanjoTooieWorld(World):
             self.multiworld.push_precollected(self.create_item(silo))
 
     def set_rules(self) -> None:
-        rules = BanjoTooieRules(self)
+        if hasattr(self.multiworld, "generation_is_fake"):
+            rules = BanjoTooieUniversalTrackerRules(self)
+        else:
+            rules = BanjoTooieRules(self)
         return rules.set_rules()
 
     def pre_fill_me(self) -> None:


### PR DESCRIPTION
This improves generation performance by removing the `state.has(itemName.UT_GLITCHED, self.player)` checks from normal generation.

Instead, when generating with Universal Tracker, a subclass of `BanjoTooieRules` is used instead, which does include the `state.has(itemName.UT_GLITCHED, self.player)` checks.

Regular generation is slightly improved by skipping checking for the UT_GLITCHED item.

I also manually forced generation to occur with the `BanjoTooieUniversalTrackerRules` subclass for a comparison. Because it is a subclass, it presumably has increased method resolution costs from its `.mro()` being longer, which I suspect explains why generation with `BanjoTooieUniversalTrackerRules` is now slower than regular generation on the current main branch. This reduction in performance is only when using Universal Tracker, so I think it is reasonable to ignore. `BanjoTooieUniversalTrackerRules` might be slightly faster if it copied and pasted the superclass methods instead of calling `super()`, but I think it is better for maintenance purposes to keep the `super()` calls.

Here is a table showing the generations I ran on main and with this PR, on Python 3.13.11 on Windows 10.

| Generation | main/s | PR/s | reduction |
| --- | --- | --- | --- |
| 10x template yaml `python -O --skip_output --skip_prog_balancing --seed 1` (23 swaps) | 7.32 (averaged over 87 trials) | 6.97 (averaged over 87 trials) | 4.72% |
| 10x template yaml, but glitches logic `python -O --skip_output --skip_prog_balancing --seed 1` (0 swaps) | 3.31 (averaged over 50 trials) | 3.22 (averaged over 50 trials) | 2.75% |
| | | | |
| 10x template yaml `python -O --skip_output --skip_prog_balancing --seed 1` (23 swaps) (forced to use `BanjoTooieUniversalTrackerRules` to mimic logic performance within Universal Tracker) | - | 7.45 (averaged over 42 trials) | -1.89% |

The changes in this PR are quite simple, thanks to Tooie's choice to use a class to hold the logic methods, so while the increase in generation performance is not huge, I think this is a worthwhile change to make given the simplicity of the changes.

From a technical standpoint, the changes in this PR should be guaranteed to always improve performance in normal generations because it is only removing code from being run in normal generations. The only extra work being done per generation with this PR is two checks of `if hasattr(self.multiworld, "generation_is_fake"):` to check for the generation being performed under Universal Tracker.

----

A potential extension to this PR is to create a subclass per logic type where each subclass has more optimised methods for checking the logic type that just return `True` or `False` without needing to check options. Similar to the `BanjoTooieUniversalTrackerRules` subclass, this is expected to incur addition method resolution costs, but it seems that the faster methods for checking the logic type result in generation being slightly faster overall. I only get a further reduction in generation duration of 0.79% for the 10x template yaml case (6.97s -> 6.92s), and it's a bit more code than in this PR, so I am not sure if the extension is worth it. I have pushed this extension to a separate branch for reference https://github.com/Mysteryem/Archipelago-ahit/commit/ef3c85fef26692c81615a2cdf2116d606cb28ea1.

An even further potential extension of this would be making each subclass per logic type override logic methods that change depending on the player's logic type, but that would be a lot of work, and it is not clear if that would result in a reasonable increase of performance for the amount of work required to make that change. To not duplicate code between each subclass, the subclasses would probably want to be tiered, e.g. the base logic becomes `BanjoTooieIntendedRules`, then `BanjoTooieEasyRules` subclasses `BanjoTooieIntendedRules` (and overrides any methods that change), then `BanjoTooieHardRules` subclasses `BanjoTooieEasyRules`, and finally `BanjoTooieGlitchedRules` subclasses `BanjoTooieHardRules`, but that could particularly make generation with `BanjoTooieGlitchedRules` slower due to the increased method resolution costs for looking up methods that are not defined on `BanjoTooieGlitchedRules`, but are defined on one of its superclasses.